### PR TITLE
Add Edit-bConnectJob.ps1

### DIFF
--- a/bConnect/Private/Invoke-bConnectPatch.ps1
+++ b/bConnect/Private/Invoke-bConnectPatch.ps1
@@ -36,7 +36,7 @@ Function Invoke-bConnectPatch() {
     try {
         If($Data.Count -gt 0) {
             $_body = ConvertTo-Json $Data
-            $_uri = "$($script:_connectUri)/$($Version)/$($Controller)"
+            $_uri = "$($script:_connectUri)/$($Version)/$($Controller)?"
 
             If(![string]::IsNullOrEmpty($objectGuid)) {
                 $_uri += "id=$($objectGuid)"

--- a/bConnect/Private/Invoke-bConnectPatch.ps1
+++ b/bConnect/Private/Invoke-bConnectPatch.ps1
@@ -6,13 +6,16 @@ Function Invoke-bConnectPatch() {
             Hashtable with parameters
         .Parameter Version
             bConnect version to use
+        .Parameter IgnoreAssignments
+            If true, bConnect will update the specified Job without error, even if it is assigned already.
     #>
 
     Param(
         [Parameter(Mandatory=$true)][string]$Controller,
         [Parameter(Mandatory=$true)][PSCustomObject]$Data,
         [string]$objectGuid,
-        [string]$Version
+        [string]$Version,
+        [boolean]$IgnoreAssignments
     )
 
     If(!$script:_connectInitialized) {
@@ -33,12 +36,17 @@ Function Invoke-bConnectPatch() {
     try {
         If($Data.Count -gt 0) {
             $_body = ConvertTo-Json $Data
+            $_uri = "$($script:_connectUri)/$($Version)/$($Controller)"
 
             If(![string]::IsNullOrEmpty($objectGuid)) {
-                $_rest = Invoke-RestMethod -Uri "$($script:_connectUri)/$($Version)/$($Controller)?id=$($objectGuid)" -Body $_body -Credential $script:_connectCredentials -Method Patch -ContentType "application/json; charset=utf-8"
-            } else {
-                $_rest = Invoke-RestMethod -Uri "$($script:_connectUri)/$($Version)/$($Controller)" -Body $_body -Credential $script:_connectCredentials -Method Patch -ContentType "application/json; charset=utf-8"
+                $_uri += "id=$($objectGuid)"
             }
+            If($IgnoreAssignments){
+                $_uri += "&ignoreAssignments=true"
+            }
+
+            $_rest = Invoke-RestMethod -Uri $_uri -Body $_body -Credential $script:_connectCredentials -Method Patch -ContentType "application/json; charset=utf-8"
+
 
             If($_rest) {
                 return $_rest

--- a/bConnect/Public/Edit-bConnectJob.ps1
+++ b/bConnect/Public/Edit-bConnectJob.ps1
@@ -1,0 +1,25 @@
+Function Edit-bConnectJob() {
+    <#
+        .Synopsis
+            Updates a existing job.
+        .Parameter Job
+            Job object (hashtable).
+        .Outputs
+            Job (see bConnect documentation for more details).
+    #>
+
+
+    Param (
+        [Parameter(Mandatory=$true)][PSCustomObject]$Job,
+        [boolean]$IgnoreAssignments = $false
+
+    )
+
+    $_connectVersion = Get-bConnectVersion
+    If($_connectVersion -ge "1.0") {
+        $_Job = ConvertTo-Hashtable $Job
+        return Invoke-bConnectPatch -Controller "Jobs" -Version $_connectVersion -objectGuid $_Job.Id -Data $_Job -IgnoreAssignments $IgnoreAssignments
+    } else {
+        return $false
+    }
+}

--- a/bConnect/Public/Edit-bConnectJob.ps1
+++ b/bConnect/Public/Edit-bConnectJob.ps1
@@ -17,8 +17,12 @@ Function Edit-bConnectJob() {
 
     $_connectVersion = Get-bConnectVersion
     If($_connectVersion -ge "1.0") {
-        $_Job = ConvertTo-Hashtable $Job
-        return Invoke-bConnectPatch -Controller "Jobs" -Version $_connectVersion -objectGuid $_Job.Id -Data $_Job -IgnoreAssignments $IgnoreAssignments
+        If(Test-Guid $Job.Id) {
+            $_Job = ConvertTo-Hashtable $Job
+            return Invoke-bConnectPatch -Controller "Jobs" -Version $_connectVersion -objectGuid $_Job.Id -Data $_Job -IgnoreAssignments $IgnoreAssignments
+        } else {
+            return $false
+        }
     } else {
         return $false
     }


### PR DESCRIPTION
Ich habe die Funktionen um Edit-bConnectJob.ps1 erweitert und mich dabei an die Form der anderen Edit-x gehalten. Es war eine Änderung an Invoke-bConnectPatch (IgnoreAssignments) notwendig, um auch Jobs ändern zu können, die bereits Endpoints zugewiesen haben.