### PR TITLE
New-bConnectApplication bugfix, NickETH-#1

### DIFF
--- a/bConnect/Private/Invoke-bConnectPost.ps1
+++ b/bConnect/Private/Invoke-bConnectPost.ps1
@@ -31,7 +31,8 @@ Function Invoke-bConnectPost() {
 
     try {
         If($Data.Count -gt 0) {
-            $_body = ConvertTo-Json $Data
+            # $_body = ConvertTo-Json $Data
+			$_body = ConvertTo-Json -InputObject $Data -Depth 5
 
             $_rest = Invoke-RestMethod -Uri "$($script:_connectUri)/$($Version)/$($Controller)" -Body $_body -Credential $script:_connectCredentials -Method Post -ContentType "application/json; charset=utf-8"
             If($_rest) {

--- a/bConnect/Public/New-bConnectApplication.ps1
+++ b/bConnect/Public/New-bConnectApplication.ps1
@@ -11,7 +11,7 @@ Function New-bConnectApplication() {
     Param (
         [Parameter(Mandatory=$true)][string]$Name,
         [Parameter(Mandatory=$true)][string]$Vendor,
-        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64","WindowsServer2019_x64",ignoreCase=$true)][string[]]$ValidForOS,
+        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64",ignoreCase=$true)][string[]]$ValidForOS,
         [string]$Comment,
         [string]$ParentId = "EAD9DFC5-1937-484A-8FCC-0977AA79F963", #guid of "Applications" as fallback
         [string]$Version,
@@ -19,7 +19,8 @@ Function New-bConnectApplication() {
         [PSCustomObject]$InstallationData,
         [PSCustomObject]$UninstallationData,
         [string]$ConsistencyChecks,
-        [PSCustomObject[]]$ApplicationFile,
+        [PSCustomObject[]]$Files,
+        [PSCustomObject[]]$SoftwareDependencies,
         [float]$Cost = 0,
         [ValidateSet("AnyUser","InstallUser","LocalInstallUser","LocalSystem","LoggedOnUser","RegisteredUser","SpecifiedUser",ignoreCase=$true)][string]$SecurityContext,
         [PSCustomObject[]]$Licenses,
@@ -53,6 +54,14 @@ Function New-bConnectApplication() {
 
 		If($InstallationData) {
 			$_body += @{ Installation = $InstallationData }
+		}
+		
+		If($Files) {
+			$_body += @{ Files = $Files }
+		}
+
+		If($SoftwareDependencies) {
+			$_body += @{ SoftwareDependencies = $SoftwareDependencies }
 		}
 
         If($UninstallationData) {

--- a/bConnect/Public/New-bConnectApplication.ps1
+++ b/bConnect/Public/New-bConnectApplication.ps1
@@ -3,7 +3,7 @@ Function New-bConnectApplication() {
         .Synopsis
             Create a new application.
         .Outputs
-            NewEndpoint (see bConnect documentation for more details).
+            NewApplication (see bConnect documentation for more details).
     #>
 
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'low')]
@@ -11,9 +11,9 @@ Function New-bConnectApplication() {
     Param (
         [Parameter(Mandatory=$true)][string]$Name,
         [Parameter(Mandatory=$true)][string]$Vendor,
-        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64",ignoreCase=$true)][string[]]$ValidForOS,
+        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64","WindowsServer2019_x64",ignoreCase=$true)][string[]]$ValidForOS,
         [string]$Comment,
-        [string]$ParentGuid = "EAD9DFC5-1937-484A-8FCC-0977AA79F963", #guid of "Applications" as fallback
+        [string]$ParentId = "EAD9DFC5-1937-484A-8FCC-0977AA79F963", #guid of "Applications" as fallback
         [string]$Version,
         [string]$Category,
         [PSCustomObject]$InstallationData,
@@ -39,8 +39,8 @@ Function New-bConnectApplication() {
 			$_body += @{ Comment = $Comment }
 		}
 
-		If(![string]::IsNullOrEmpty($ParentGuid)) {
-			$_body += @{ ParentGuid = $ParentGuid }
+		If(![string]::IsNullOrEmpty($ParentId)) {
+			$_body += @{ ParentId = $ParentId }
 		}
 
 		If(![string]::IsNullOrEmpty($Version)) {

--- a/bConnect/Public/New-bConnectApplication.ps1
+++ b/bConnect/Public/New-bConnectApplication.ps1
@@ -11,7 +11,7 @@ Function New-bConnectApplication() {
     Param (
         [Parameter(Mandatory=$true)][string]$Name,
         [Parameter(Mandatory=$true)][string]$Vendor,
-        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64",ignoreCase=$true)][string[]]$ValidForOS,
+        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64","WindowsServer2016_x64",ignoreCase=$true)][string[]]$ValidForOS,
         [string]$Comment,
         [string]$ParentId = "EAD9DFC5-1937-484A-8FCC-0977AA79F963", #guid of "Applications" as fallback
         [string]$Version,

--- a/bConnect/Public/New-bConnectApplicationDependency.ps1
+++ b/bConnect/Public/New-bConnectApplicationDependency.ps1
@@ -21,8 +21,6 @@ Function New-bConnectApplicationDependency() {
 		[Parameter(Mandatory=$true)][string]$DependencyAppName,
         [Parameter(Mandatory=$true)][ValidateSet("InstallBeforeIfNotInstalled","AlwaysInstallAfterwards","AlwaysInstallBefore","DeinstallBeforeIfInstalled","ErrorIfNotInstalled","ErrorIfInstalled",ignoreCase=$true)][string]$DependencyType,
         [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64","WindowsServer2019_x64",ignoreCase=$true)][array]$ValidForOS
-#		[Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64",ignoreCase=$true)][string[]]$ValidForOS
-#		[Parameter(Mandatory=$true)][string]$ValidForOS
     )
 
     $_new_Dependency = @{

--- a/bConnect/Public/New-bConnectApplicationDependency.ps1
+++ b/bConnect/Public/New-bConnectApplicationDependency.ps1
@@ -1,0 +1,50 @@
+Function New-bConnectApplicationDependency() {
+    <#
+        .Synopsis
+            Creates a new Dependency for Applications.
+            Empty or filled with given information.
+        .Parameter DependencyId
+            Guid of Application to use in Dependency
+        .Parameter DependencyAppName
+            Name of Application to use in Dependency
+		.Parameter DependencyType
+            Parameter with DependencyType
+		.Parameter ValidForOS
+            Parameter with ValidForOS
+        .Outputs
+            Dependency entry (see bConnect documentation for more details)
+    #>
+
+    [OutputType("System.Management.Automations.PSObject")]
+    Param(
+		[Parameter(Mandatory=$true)][string]$DependencyId,
+		[Parameter(Mandatory=$true)][string]$DependencyAppName,
+        [Parameter(Mandatory=$true)][ValidateSet("InstallBeforeIfNotInstalled","AlwaysInstallAfterwards","AlwaysInstallBefore","DeinstallBeforeIfInstalled","ErrorIfNotInstalled","ErrorIfInstalled",ignoreCase=$true)][string]$DependencyType,
+        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64","WindowsServer2019_x64",ignoreCase=$true)][array]$ValidForOS
+#		[Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64",ignoreCase=$true)][string[]]$ValidForOS
+#		[Parameter(Mandatory=$true)][string]$ValidForOS
+    )
+
+    $_new_Dependency = @{
+        DependencyId = $DependencyId;
+        DependencyAppName = $DependencyAppName;
+        DependencyType = $DependencyType;
+        ValidForOS = $ValidForOS
+    }
+<#     If(![string]::IsNullOrEmpty($DependencyId)) {
+        $_new_Dependency += @{ DependencyId = $DependencyId }
+    }
+
+    If(![string]::IsNullOrEmpty($DependencyAppName)) {
+        $_new_Dependency += @{ DependencyAppName = $DependencyAppName }
+    }
+
+    If(![string]::IsNullOrEmpty($DependencyType)) {
+        $_new_Dependency += @{ DependencyType = $DependencyType }
+    }
+
+    If(![string]::IsNullOrEmpty($ValidForOS)) {
+        $_new_Dependency += @{ ValidForOS = $ValidForOS } #>
+
+    return $_new_Dependency
+}

--- a/bConnect/Public/New-bConnectApplicationInstallOptions.ps1
+++ b/bConnect/Public/New-bConnectApplicationInstallOptions.ps1
@@ -26,12 +26,12 @@ Function New-bConnectApplicationInstallOptions() {
     [OutputType("System.Management.Automations.PSObject")]
     Param(
         [ValidateSet("NoReboot","Reboot","AppReboot","DeferrableReboot",ignoreCase=$true)][string]$RebootBehaviour = "NoReboot",
-        [switch]$AllowReinstall = $true,
-        [switch]$UsebBT,
+        [bool]$AllowReinstall = $true,
+        [bool]$UsebBT,
         [ValidateSet("Silent","NeedsDesktop","VisibleWhenUserLoggedOn",ignoreCase=$true)][string]$VisibleExecution = "Silent",
-        [switch]$CopyLocally,
-        [switch]$DisableInputDevices,
-        [switch]$DontSetAsInstalled,
+        [bool]$CopyLocally,
+        [bool]$DisableInputDevices,
+        [bool]$DontSetAsInstalled,
         [string]$Target
     )
 


### PR DESCRIPTION
Hallo Alexander,
die Funktion New-bConnectApplication hat einen falschen Parameter "ParentGuid".
Dieser muss "ParentId" heissen.
Bis jetzt scheint das noch nie jemand getestet zu haben.
Dieser Fehler war schon bei der Github-Version von F. Weinmann vorhanden.
Der PR korriegiert diesen und noch einen kosmetische Eintrag.
Bitte um Merge.
Gruss, Nick