### PR TITLE
Adding 2020R1 to supported versions

### DIFF
--- a/bConnect/Private/Get-bConnectVersion.ps1
+++ b/bConnect/Private/Get-bConnectVersion.ps1
@@ -43,6 +43,10 @@ Function Get-bConnectVersion() {
 				Write-Verbose "bConnect 2019R1 or newer"
 			}
 
+			"20.*" {
+				Write-Verbose "bConnect 2020R1 or newer"
+			}
+
             default {
                 Write-Warning "NOT SUPPORTED! Unknown bConnect Version -> Fallback to $($script:_bConnectFallbackVersion)"
                 $_bcVersion = $script:_bConnectFallbackVersion


### PR DESCRIPTION
Accept version 20.x without fallback to bConnect 1.0