### PR TITLE
fixes #32

### DIFF
--- a/bConnect/Public/Edit-bConnectStaticGroup.ps1
+++ b/bConnect/Public/Edit-bConnectStaticGroup.ps1
@@ -35,7 +35,7 @@
 
             $_endpointIds = @()
             Foreach($_ep in $StaticGroup.EndpointIds) {
-                $_endpointIds += $_ep.Id
+                $_endpointIds += $_ep
             }
             $StaticGroup.EndpointIds = $_endpointIds
 


### PR DESCRIPTION
Fix funktioniert nur wenn Gruppe nicht mehr als x Endpoints enthält
(Getestet mit ca. 1200 Clients, dort schlägt es fehl, weniger als 1000 sind OK)