### PR TITLE
Make property MicrosoftUpdateProfile writable

### DIFF
--- a/bConnect/Public/Edit-bConnectEndpoint.ps1
+++ b/bConnect/Public/Edit-bConnectEndpoint.ps1
@@ -28,7 +28,7 @@ Function Edit-bConnectEndpoint() {
 			$_propertyList = @(
                 "DisplayName",
                 "GuidOrgUnit",
-        		"Comments"
+                "Comments"
             )
             $Endpoint = ConvertTo-Hashtable $Endpoint
 
@@ -44,11 +44,12 @@ Function Edit-bConnectEndpoint() {
                     "PublicKey",
                     "Mode",
                     "ExtendedInternetMode",
-		            "PrimaryUser",
-		            "PrimaryIP",
-		            "CustomStateText",
-		            "CustomStateType",
-                    "UserCategory"
+                    "PrimaryUser",
+                    "PrimaryIP",
+                    "CustomStateText",
+                    "CustomStateType",
+                    "UserCategory",
+                    "MicrosoftUpdateProfile"
                 )
 			}
 


### PR DESCRIPTION
This change allows you to set the update profile for a client.

Also replaced tab indention with spaces.