### PR TITLE
Update OS-validate-sets with Win11/Server22

### DIFF
--- a/bConnect/Public/New-bConnectApplication.ps1
+++ b/bConnect/Public/New-bConnectApplication.ps1
@@ -11,7 +11,7 @@
     Param (
         [Parameter(Mandatory=$true)][string]$Name,
         [Parameter(Mandatory=$true)][string]$Vendor,
-        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64","WindowsServer2019_x64",ignoreCase=$true)][string[]]$ValidForOS,
+        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","Windows11_x64","WindowsServer2016_x64","WindowsServer2019_x64","WindowsServer2022_x64",ignoreCase=$true)][string[]]$ValidForOS,
         [string]$Comment,
         [string]$ParentId = "EAD9DFC5-1937-484A-8FCC-0977AA79F963", #guid of "Applications" as fallback
         [string]$Version,

--- a/bConnect/Public/New-bConnectApplicationDependency.ps1
+++ b/bConnect/Public/New-bConnectApplicationDependency.ps1
@@ -21,7 +21,7 @@ Function New-bConnectApplicationDependency() {
 		[Parameter(Mandatory=$true)][string]$DependencyId,
 		[Parameter(Mandatory=$true)][string]$DependencyAppName,
         [Parameter(Mandatory=$true)][ValidateSet("InstallBeforeIfNotInstalled","AlwaysInstallAfterwards","AlwaysInstallBefore","DeinstallBeforeIfInstalled","ErrorIfNotInstalled","ErrorIfInstalled",ignoreCase=$true)][string]$DependencyType,
-        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","WindowsServer2016_x64","WindowsServer2019_x64",ignoreCase=$true)][array]$ValidForOS
+        [Parameter(Mandatory=$true)][ValidateSet("NT4","Windows2000","WindowsXP","WindowsServer2003","WindowsVista","WindowsServer2008","Windows7","WindowsServer2008R2","WindowsXP_x64","WindowsServer2003_x64","WindowsVista_x64","WindowsServer2008_x64","Windows7_x64","WindowsServer2008R2_x64","Windows8","WindowsServer2012","Windows8_x64","WindowsServer2012_x64","Windows10","Windows10_x64","Windows11_x64","WindowsServer2016_x64","WindowsServer2019_x64","WindowsServer2022_x64",ignoreCase=$true)][array]$ValidForOS
     )
 
     $_new_Dependency = @{


### PR DESCRIPTION
Add entries for Windows 11 and Server 2022 to the validate sets.