### PR TITLE
fix ignore certificates error (PS6.x and higher)

### DIFF
--- a/bConnect/Public/Initialize-bConnect.ps1
+++ b/bConnect/Public/Initialize-bConnect.ps1
@@ -22,7 +22,7 @@ Function Initialize-bConnect() {
     )
 
     If($AcceptSelfSignedCertificate) {
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object ignoreCertificatePolicy
+        [ServerCertificateValidationCallback]::Ignore(); 
     }
 
     $_uri = "https://$($Server):$($Port)/bConnect"
@@ -31,3 +31,4 @@ Function Initialize-bConnect() {
     $script:_connectCredentials = $Credentials
     $script:_connectInitialized = $true
 }
+

--- a/bConnect/bConnect.psm1
+++ b/bConnect/bConnect.psm1
@@ -18,13 +18,27 @@ $script:_ConnectionTimeout = 0
 
 # Only to ignore certificates errors (self-signed)
 Add-Type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-
-public class ignoreCertificatePolicy : ICertificatePolicy {
-    public ignoreCertificatePolicy() {}
-    public bool CheckValidationResult(ServicePoint sPoint, X509Certificate cert, WebRequest wRequest, int certProb) { return true; }
-}
+        using System;
+        using System.Net;
+        using System.Net.Security;
+        using System.Security.Cryptography.X509Certificates;
+        public class ServerCertificateValidationCallback
+        {
+            public static void Ignore()
+            {
+                ServicePointManager.ServerCertificateValidationCallback += 
+                    delegate
+                    (
+                        Object obj, 
+                        X509Certificate certificate, 
+                        X509Chain chain, 
+                        SslPolicyErrors errors
+                    )
+                    {
+                        return true;
+                    };
+            }
+        }
 "@
 
 # init the connection (uri and credentials)


### PR DESCRIPTION
# **UNTESTET**
code from:
https://www.msxfaq.de/code/powershell/powershell_und_zertifikate_check.htm

closes #53

created as draft until the PowerShell Versions are tested.
(fyi: PowerShell 6.x got a paramter to skip the SSL check (-SkipCertificateCheck))