### PR TITLE
Update Versionsprüfung

### DIFF
--- a/bConnect/Public/Edit-bConnectApplication.ps1
+++ b/bConnect/Public/Edit-bConnectApplication.ps1
@@ -19,7 +19,7 @@ Function Edit-bConnectApplication() {
 
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $Application.Id) {
             $_Application = ConvertTo-Hashtable $Application
             return Invoke-bConnectPatch -Controller "Applications" -Version $_connectVersion -objectGuid $_Application.Id -Data $_Application

--- a/bConnect/Public/Edit-bConnectDynamicGroup.ps1
+++ b/bConnect/Public/Edit-bConnectDynamicGroup.ps1
@@ -14,7 +14,7 @@ Function Edit-bConnectDynamicGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $DynamicGroup.Id) {
             # bms2016r1
             # We can not send the whole object because of not editable fields.

--- a/bConnect/Public/Edit-bConnectEndpoint.ps1
+++ b/bConnect/Public/Edit-bConnectEndpoint.ps1
@@ -14,7 +14,7 @@ Function Edit-bConnectEndpoint() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $Endpoint.Id) {
             # We can not send the whole object because of not editable fields.
             # So we need to create a new one with editable fields only...

--- a/bConnect/Public/Edit-bConnectIpNetwork.ps1
+++ b/bConnect/Public/Edit-bConnectIpNetwork.ps1
@@ -15,7 +15,7 @@ Function Edit-bConnectIpNetwork() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $IpNetwork.Id) {
             $_IpNetwork = ConvertTo-Hashtable $IpNetwork
             return Invoke-bConnectPatch -Controller "IpNetworks" -Version $_connectVersion -objectGuid $_IpNetwork.Id -Data $_IpNetwork

--- a/bConnect/Public/Edit-bConnectJob.ps1
+++ b/bConnect/Public/Edit-bConnectJob.ps1
@@ -16,7 +16,7 @@ Function Edit-bConnectJob() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $Job.Id) {
             $_Job = ConvertTo-Hashtable $Job
             return Invoke-bConnectPatch -Controller "Jobs" -Version $_connectVersion -objectGuid $_Job.Id -Data $_Job -IgnoreAssignments $IgnoreAssignments

--- a/bConnect/Public/Edit-bConnectOrgUnit.ps1
+++ b/bConnect/Public/Edit-bConnectOrgUnit.ps1
@@ -14,7 +14,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $OrgUnit.Id) {
             $_orgUnit = ConvertTo-Hashtable $OrgUnit
             return Invoke-bConnectPatch -Controller "OrgUnits" -Version $_connectVersion -objectGuid $OrgUnit.Id -Data $_orgUnit

--- a/bConnect/Public/Edit-bConnectStaticGroup.ps1
+++ b/bConnect/Public/Edit-bConnectStaticGroup.ps1
@@ -14,7 +14,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $StaticGroup.Id) {
             # bms2016r1
             # We can not send the whole object because of not editable fields.

--- a/bConnect/Public/Edit-bConnectVariableDefinition.ps1
+++ b/bConnect/Public/Edit-bConnectVariableDefinition.ps1
@@ -15,7 +15,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $VariableDefinition.Id) {
             $_body = @{
                 Scope = $VariableDefinition.Scope;

--- a/bConnect/Public/Get-bConnectApp.ps1
+++ b/bConnect/Public/Get-bConnectApp.ps1
@@ -20,7 +20,7 @@ Function Get-bConnectApp() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($EndpointGuid) {
             $_body = @{
                 EndpointId = $EndpointGuid

--- a/bConnect/Public/Get-bConnectAppIcon.ps1
+++ b/bConnect/Public/Get-bConnectAppIcon.ps1
@@ -17,7 +17,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($Scope) {
             $_body = @{
                 Scope = [string]$Scope

--- a/bConnect/Public/Get-bConnectApplication.ps1
+++ b/bConnect/Public/Get-bConnectApplication.ps1
@@ -20,7 +20,7 @@ Function Get-bConnectApplication() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($EndpointGuid) {
             $_body = @{
                 EndpointId = $EndpointGuid

--- a/bConnect/Public/Get-bConnectBootEnv.ps1
+++ b/bConnect/Public/Get-bConnectBootEnv.ps1
@@ -14,7 +14,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($BootEnvironmentGuid) {
             $_body = @{
                 Id = $BootEnvironmentGuid

--- a/bConnect/Public/Get-bConnectDynamicGroup.ps1
+++ b/bConnect/Public/Get-bConnectDynamicGroup.ps1
@@ -17,7 +17,7 @@ Function Get-bConnectDynamicGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(![string]::IsNullOrEmpty($DynamicGroup)) {
             If(Test-Guid $DynamicGroup) {
                 $_body = @{

--- a/bConnect/Public/Get-bConnectEndpoint.ps1
+++ b/bConnect/Public/Get-bConnectEndpoint.ps1
@@ -38,7 +38,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{}
         If($EndpointGuid) {
             $_body = @{

--- a/bConnect/Public/Get-bConnectEndpointInvSoftware.ps1
+++ b/bConnect/Public/Get-bConnectEndpointInvSoftware.ps1
@@ -10,7 +10,7 @@ Function Get-bConnectEndpointInvSoftware() {
     Param ()
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
 
         return Invoke-bConnectGet -Controller "EndpointInvSoftware" -Version $_connectVersion -Data $_body
     } else {

--- a/bConnect/Public/Get-bConnectEndpointSecret.ps1
+++ b/bConnect/Public/Get-bConnectEndpointSecret.ps1
@@ -14,7 +14,7 @@ Function Get-bConnectEndpointSecret() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             EndpointId = $EndpointGuid
         }

--- a/bConnect/Public/Get-bConnectHardwareProfile.ps1
+++ b/bConnect/Public/Get-bConnectHardwareProfile.ps1
@@ -14,7 +14,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($HardwareProfileGuid) {
             $_body = @{
                 Id = $HardwareProfileGuid

--- a/bConnect/Public/Get-bConnectImage.ps1
+++ b/bConnect/Public/Get-bConnectImage.ps1
@@ -14,7 +14,7 @@ Function Get-bConnectImage() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $Id
         }

--- a/bConnect/Public/Get-bConnectInventoryAppScan.ps1
+++ b/bConnect/Public/Get-bConnectInventoryAppScan.ps1
@@ -14,7 +14,7 @@ Function Get-bConnectInventoryAppScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($EndpointGuid) {
             $_body = @{
                 EndpointId = $EndpointGuid

--- a/bConnect/Public/Get-bConnectInventoryDataCustomScan.ps1
+++ b/bConnect/Public/Get-bConnectInventoryDataCustomScan.ps1
@@ -20,7 +20,7 @@ Function Get-bConnectInventoryDataCustomScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{}
         If($EndpointGuid) {
             $_body += @{ EndpointId = $EndpointGuid }

--- a/bConnect/Public/Get-bConnectInventoryDataFileScan.ps1
+++ b/bConnect/Public/Get-bConnectInventoryDataFileScan.ps1
@@ -14,7 +14,7 @@ Function Get-bConnectInventoryDataFileScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($EndpointGuid) {
             $_body = @{
                 EndpointId = $EndpointGuid

--- a/bConnect/Public/Get-bConnectInventoryDataHardwareScan.ps1
+++ b/bConnect/Public/Get-bConnectInventoryDataHardwareScan.ps1
@@ -20,7 +20,7 @@ Function Get-bConnectInventoryDataHardwareScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{}
         If($EndpointGuid) {
             $_body += @{ EndpointId = $EndpointGuid }

--- a/bConnect/Public/Get-bConnectInventoryDataRegistryScan.ps1
+++ b/bConnect/Public/Get-bConnectInventoryDataRegistryScan.ps1
@@ -14,7 +14,7 @@ Function Get-bConnectInventoryDataRegistryScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($EndpointGuid) {
             $_body = @{
                 EndpointId = $EndpointGuid

--- a/bConnect/Public/Get-bConnectInventoryDataSnmpScan.ps1
+++ b/bConnect/Public/Get-bConnectInventoryDataSnmpScan.ps1
@@ -14,7 +14,7 @@ Function Get-bConnectInventoryDataSnmpScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($EndpointGuid) {
             $_body = @{
                 EndpointId = $EndpointGuid

--- a/bConnect/Public/Get-bConnectInventoryDataWmiScan.ps1
+++ b/bConnect/Public/Get-bConnectInventoryDataWmiScan.ps1
@@ -20,7 +20,7 @@ Function Get-bConnectInventoryDataWmiScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{}
         If($EndpointGuid) {
             $_body += @{ EndpointId = $EndpointGuid }

--- a/bConnect/Public/Get-bConnectInventoryOverview.ps1
+++ b/bConnect/Public/Get-bConnectInventoryOverview.ps1
@@ -14,7 +14,7 @@ Function Get-bConnectInventoryOverview() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($EndpointGuid) {
             $_body = @{
                 EndpointId = $EndpointGuid

--- a/bConnect/Public/Get-bConnectIpNetwork.ps1
+++ b/bConnect/Public/Get-bConnectIpNetwork.ps1
@@ -17,7 +17,7 @@ Function Get-bConnectIpNetwork() {
         )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($Name) {
             $_body = @{
                 Name = $Name

--- a/bConnect/Public/Get-bConnectJob.ps1
+++ b/bConnect/Public/Get-bConnectJob.ps1
@@ -21,7 +21,7 @@ Function Get-bConnectJob() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($JobGuid) {
             $_body = @{
                 Id = $JobGuid

--- a/bConnect/Public/Get-bConnectJobInstance.ps1
+++ b/bConnect/Public/Get-bConnectJobInstance.ps1
@@ -23,7 +23,7 @@ Function Get-bConnectJobInstance() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($JobGuid) {
             $_body = @{
                 JobId = $JobGuid

--- a/bConnect/Public/Get-bConnectKioskJob.ps1
+++ b/bConnect/Public/Get-bConnectKioskJob.ps1
@@ -23,7 +23,7 @@ Function Get-bConnectKioskJob() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If($Username) {
             $_body = @{
                 User = $Username

--- a/bConnect/Public/Get-bConnectOrgUnit.ps1
+++ b/bConnect/Public/Get-bConnectOrgUnit.ps1
@@ -18,7 +18,7 @@ Function Get-bConnectOrgUnit() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(Test-Guid $OrgUnit) {
             If($SubGroups) {
                 $_body = @{

--- a/bConnect/Public/Get-bConnectServerState.ps1
+++ b/bConnect/Public/Get-bConnectServerState.ps1
@@ -10,7 +10,7 @@
     Param ()
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         return Invoke-bConnectGet -Controller "ServerState" -Version $_connectVersion
     } else {
         return $false

--- a/bConnect/Public/Get-bConnectSoftwareScanRule.ps1
+++ b/bConnect/Public/Get-bConnectSoftwareScanRule.ps1
@@ -10,7 +10,7 @@ Function Get-bConnectSoftwareScanRule() {
     Param ()
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
 
         return Invoke-bConnectGet -Controller "SoftwareScanRules" -Version $_connectVersion -Data $_body
     } else {

--- a/bConnect/Public/Get-bConnectSoftwareScanRuleCounts.ps1
+++ b/bConnect/Public/Get-bConnectSoftwareScanRuleCounts.ps1
@@ -10,7 +10,7 @@ Function Get-bConnectSoftwareScanRuleCounts() {
     Param ()
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
 
         return Invoke-bConnectGet -Controller "SoftwareScanRuleCounts" -Version $_connectVersion -Data $_body
     } else {

--- a/bConnect/Public/Get-bConnectStaticGroup.ps1
+++ b/bConnect/Public/Get-bConnectStaticGroup.ps1
@@ -17,7 +17,7 @@ Function Get-bConnectStaticGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(![string]::IsNullOrEmpty($StaticGroup)) {
             If(Test-Guid $StaticGroup) {
                 $_body = @{

--- a/bConnect/Public/Get-bConnectUniversalDynamicGroup.ps1
+++ b/bConnect/Public/Get-bConnectUniversalDynamicGroup.ps1
@@ -20,7 +20,7 @@ Function Get-bConnectUniversalDynamicGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{}
 
         if(![string]::IsNullOrEmpty($IsArgusSynced)) {

--- a/bConnect/Public/Get-bConnectVariable.ps1
+++ b/bConnect/Public/Get-bConnectVariable.ps1
@@ -23,7 +23,7 @@ Function Get-bConnectVariable() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{ Scope = $Scope.ToString() }
 
         If($Category) {

--- a/bConnect/Public/Get-bConnectVariableDefinition.ps1
+++ b/bConnect/Public/Get-bConnectVariableDefinition.ps1
@@ -23,7 +23,7 @@ Function Get-bConnectVariableDefinition() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{}
 
         If($Id) {

--- a/bConnect/Public/New-bConnectApplication.ps1
+++ b/bConnect/Public/New-bConnectApplication.ps1
@@ -28,7 +28,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Name = $Name;
             Vendor = $Vendor;

--- a/bConnect/Public/New-bConnectDynamicGroup.ps1
+++ b/bConnect/Public/New-bConnectDynamicGroup.ps1
@@ -24,7 +24,7 @@ Function New-bConnectDynamicGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Name = $Name;
             ParentId = $ParentGuid;

--- a/bConnect/Public/New-bConnectEndpoint.ps1
+++ b/bConnect/Public/New-bConnectEndpoint.ps1
@@ -37,7 +37,7 @@ Function New-bConnectEndpoint() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             DisplayName = $displayname;
             GuidOrgUnit = $GuidOrgUnit;

--- a/bConnect/Public/New-bConnectEndpointEnrollment.ps1
+++ b/bConnect/Public/New-bConnectEndpointEnrollment.ps1
@@ -21,7 +21,7 @@ Function New-bConnectEndpointEnrollment() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             EndpointId = $EndpointId;
         }

--- a/bConnect/Public/New-bConnectIpNetwork.ps1
+++ b/bConnect/Public/New-bConnectIpNetwork.ps1
@@ -23,7 +23,7 @@ Function New-bConnectIpNetwork() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Name = $Name;
             Scopes = $Scopes;

--- a/bConnect/Public/New-bConnectJobInstance.ps1
+++ b/bConnect/Public/New-bConnectJobInstance.ps1
@@ -24,7 +24,7 @@ Function New-bConnectJobInstance() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             EndpointId = $EndpointGuid;
             JobId = $JobGuid;

--- a/bConnect/Public/New-bConnectKioskJob.ps1
+++ b/bConnect/Public/New-bConnectKioskJob.ps1
@@ -22,7 +22,7 @@ Function New-bConnectKioskJob() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             JobDefinitionId = $JobDefinitionId;
         }

--- a/bConnect/Public/New-bConnectOrgUnit.ps1
+++ b/bConnect/Public/New-bConnectOrgUnit.ps1
@@ -24,7 +24,7 @@ Function New-bConnectOrgUnit() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Name = $Name;
             ParentId = $ParentGuid;

--- a/bConnect/Public/New-bConnectStaticGroup.ps1
+++ b/bConnect/Public/New-bConnectStaticGroup.ps1
@@ -24,7 +24,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Name = $Name;
             ParentId = $ParentGuid;

--- a/bConnect/Public/New-bConnectVariableDefinition.ps1
+++ b/bConnect/Public/New-bConnectVariableDefinition.ps1
@@ -24,7 +24,7 @@ Function New-bConnectVariableDefinition() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Scope = $Scope.ToString();
             Category = $Category;

--- a/bConnect/Public/Remove-bConnectApplication.ps1
+++ b/bConnect/Public/Remove-bConnectApplication.ps1
@@ -18,7 +18,7 @@ Function Remove-bConnectApplication() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(![string]::IsNullOrEmpty($ApplicationGuid)) {
             $_body = @{
                 Id = $ApplicationGuid

--- a/bConnect/Public/Remove-bConnectDynamicGroup.ps1
+++ b/bConnect/Public/Remove-bConnectDynamicGroup.ps1
@@ -15,7 +15,7 @@ Function Remove-bConnectDynamicGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $DynamicGroupGuid
         }

--- a/bConnect/Public/Remove-bConnectEndpoint.ps1
+++ b/bConnect/Public/Remove-bConnectEndpoint.ps1
@@ -18,7 +18,7 @@ Function Remove-bConnectEndpoint() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(![string]::IsNullOrEmpty($EndpointGuid)) {
             $_body = @{
                 Id = $EndpointGuid

--- a/bConnect/Public/Remove-bConnectInventoryDataFileScan.ps1
+++ b/bConnect/Public/Remove-bConnectInventoryDataFileScan.ps1
@@ -15,7 +15,7 @@ Function Remove-bConnectInventoryDataFileScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             EndpointId = $EndpointGuid;
         }

--- a/bConnect/Public/Remove-bConnectInventoryDataRegistryScan.ps1
+++ b/bConnect/Public/Remove-bConnectInventoryDataRegistryScan.ps1
@@ -15,7 +15,7 @@ Function Remove-bConnectInventoryDataRegistryScan() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             EndpointId = $EndpointGuid;
         }

--- a/bConnect/Public/Remove-bConnectIpNetwork.ps1
+++ b/bConnect/Public/Remove-bConnectIpNetwork.ps1
@@ -20,7 +20,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(![string]::IsNullOrEmpty($IpNetworkGuid)) {
             $_body = @{
                 Id = $IpNetworkGuid

--- a/bConnect/Public/Remove-bConnectJob.ps1
+++ b/bConnect/Public/Remove-bConnectJob.ps1
@@ -16,7 +16,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(![string]::IsNullOrEmpty($JobGuid)) {
             $_body = @{
                 Id = $JobGuid

--- a/bConnect/Public/Remove-bConnectJobInstance.ps1
+++ b/bConnect/Public/Remove-bConnectJobInstance.ps1
@@ -15,7 +15,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $JobInstanceGuid
         }

--- a/bConnect/Public/Remove-bConnectKioskJob.ps1
+++ b/bConnect/Public/Remove-bConnectKioskJob.ps1
@@ -16,7 +16,7 @@ Function Remove-bConnectKioskJob() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         If(![string]::IsNullOrEmpty($KioskJobId)) {
             $_body = @{
                 KioskJobId = $KioskJobId

--- a/bConnect/Public/Remove-bConnectOrgUnit.ps1
+++ b/bConnect/Public/Remove-bConnectOrgUnit.ps1
@@ -15,7 +15,7 @@ Function Remove-bConnectOrgUnit() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $OrgUnitGuid
         }

--- a/bConnect/Public/Remove-bConnectStaticGroup.ps1
+++ b/bConnect/Public/Remove-bConnectStaticGroup.ps1
@@ -15,7 +15,7 @@ Function Remove-bConnectStaticGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $StaticGroupGuid
         }

--- a/bConnect/Public/Resume-bConnectJobInstance.ps1
+++ b/bConnect/Public/Resume-bConnectJobInstance.ps1
@@ -15,7 +15,7 @@ Function Resume-bConnectJobInstance() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $JobInstanceGuid;
             Cmd = "resume"

--- a/bConnect/Public/Search-bConnectApplication.ps1
+++ b/bConnect/Public/Search-bConnectApplication.ps1
@@ -14,7 +14,7 @@ Function Search-bConnectApplication() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Type = "software";
             Term = $Term

--- a/bConnect/Public/Search-bConnectDynamicGroup.ps1
+++ b/bConnect/Public/Search-bConnectDynamicGroup.ps1
@@ -14,7 +14,7 @@ Function Search-bConnectDynamicGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Type = "group";
             Term = $Term

--- a/bConnect/Public/Search-bConnectEndpoint.ps1
+++ b/bConnect/Public/Search-bConnectEndpoint.ps1
@@ -14,7 +14,7 @@ Function Search-bConnectEndpoint() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Type = "endpoint";
             Term = $Term

--- a/bConnect/Public/Search-bConnectGroup.ps1
+++ b/bConnect/Public/Search-bConnectGroup.ps1
@@ -14,7 +14,7 @@ Function Search-bConnectGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Type = "group";
             Term = $Term

--- a/bConnect/Public/Search-bConnectJob.ps1
+++ b/bConnect/Public/Search-bConnectJob.ps1
@@ -14,7 +14,7 @@ Function Search-bConnectJob() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Type = "job";
             Term = $Term

--- a/bConnect/Public/Search-bConnectOrgUnit.ps1
+++ b/bConnect/Public/Search-bConnectOrgUnit.ps1
@@ -14,7 +14,7 @@ Function Search-bConnectOrgUnit() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Type = "orgunit";
             Term = $Term

--- a/bConnect/Public/Search-bConnectStaticGroup.ps1
+++ b/bConnect/Public/Search-bConnectStaticGroup.ps1
@@ -14,7 +14,7 @@ Function Search-bConnectStaticGroup() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Type = "group";
             Term = $Term

--- a/bConnect/Public/Set-bConnectEndpointSecret.ps1
+++ b/bConnect/Public/Set-bConnectEndpointSecret.ps1
@@ -18,7 +18,7 @@ Function Set-bConnectEndpointSecret() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             EndpointId = $EndpointGuid;
             Pin = $Pin

--- a/bConnect/Public/Set-bConnectVariable.ps1
+++ b/bConnect/Public/Set-bConnectVariable.ps1
@@ -27,7 +27,7 @@
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_variable = @{
             Category = $Category;
             Name = $Name;

--- a/bConnect/Public/Start-bConnectJobInstance.ps1
+++ b/bConnect/Public/Start-bConnectJobInstance.ps1
@@ -15,7 +15,7 @@ Function Start-bConnectJobInstance() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $JobInstanceGuid;
             Cmd = "start"

--- a/bConnect/Public/Stop-bConnectJobInstance.ps1
+++ b/bConnect/Public/Stop-bConnectJobInstance.ps1
@@ -15,7 +15,7 @@ Function Stop-bConnectJobInstance() {
     )
 
     $_connectVersion = Get-bConnectVersion
-    If($_connectVersion -ge "1.0") {
+    If($_connectVersion -ge "v1.0") {
         $_body = @{
             Id = $JobInstanceGuid;
             Cmd = "stop"


### PR DESCRIPTION
In mehreren dutzend Dateien gibt es die bConnect Versionsprüfung
If($_connectVersion -ge "1.0") {
Dieser Vergleich gibt IMMER $True zurück, da aus Get-bConnectVersion nicht "1.x" zurück kommt, sondern "**v**1.x"
Die bConnect Versionsprüfung müsste also wie folgt aussehen:
If($_connectVersion -ge "v1.0") {