### PR TITLE
basic PowerShell 7 compatibility

### DIFF
--- a/bConnect/Private/Invoke-bConnectDelete.ps1
+++ b/bConnect/Private/Invoke-bConnectDelete.ps1
@@ -36,7 +36,18 @@ Function Invoke-bConnectDelete() {
             $_params += "$($_key)=$($Data.Get_Item($_key))"
         }
 
-        $_rest = Invoke-RestMethod -Uri "$($script:_connectUri)/$($Version)/$($Controller)?$($_params)" -Credential $script:_connectCredentials -Method Delete -ContentType "application/json; charset=utf-8"
+        $invokeParams = @{
+            Uri = "$($script:_connectUri)/$($Version)/$($Controller)?$($_params)"
+            Credential = $script:_connectCredentials
+            Method = 'Delete'
+            ContentType = 'application/json; charset=utf-8'
+        }
+
+        if ($script:_skipCertificateCheck) {
+            $invokeParams.SkipCertificateCheck = $true
+        }
+
+        $_rest = Invoke-RestMethod @invokeParams
         If($_rest) {
             return $_rest
         } else {
@@ -48,9 +59,19 @@ Function Invoke-bConnectDelete() {
         $_errMsg = ""
 
         Try {
-            $_response = ConvertFrom-Json $_
+            if ($PSVersionTable.PSEdition -eq 'Core') {
+                # In PowerShell 7+, the actual response is in the stream of the exception's response object
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($stream)
+                $responseBody = $reader.ReadToEnd()
+                $reader.Close()
+                $stream.Close()
+                $_response = ConvertFrom-Json $responseBody
+            } else {
+                # In Windows PowerShell 5.1, the error record itself can sometimes be converted
+                $_response = ConvertFrom-Json $_
+            }
         }
-
         Catch {
             $_response = $false
         }
@@ -58,11 +79,11 @@ Function Invoke-bConnectDelete() {
         If($_response) {
             $_errMsg = $_response.Message
         } else {
-            $_errMsg =  $_
+            $_errMsg =  $_.Exception.Message
         }
 
-        If($_body) {
-            $_errMsg = "$($_errMsg) `nHashtable: $($Data)"
+        If($Data) {
+            $_errMsg = "$($_errMsg) `nData: $($Data | Out-String)"
         }
 
         Write-Error $_errMsg

--- a/bConnect/Private/Invoke-bConnectGet.ps1
+++ b/bConnect/Private/Invoke-bConnectGet.ps1
@@ -40,11 +40,24 @@ Function Invoke-bConnectGet() {
     }
 
     try {
-        If($Data.Count -gt 0) {
-            $_rest = Invoke-RestMethod -Uri $_uri -Body $Data -Credential $script:_connectCredentials -Method Get -ContentType "application/json; charset=utf-8" -TimeoutSec $script:_ConnectionTimeout
-        } else {
-            $_rest = Invoke-RestMethod -Uri $_uri -Credential $script:_connectCredentials -Method Get -ContentType "application/json; charset=utf-8" -TimeoutSec $script:_ConnectionTimeout
+        $invokeParams = @{
+            Uri = $_uri
+            Credential = $script:_connectCredentials
+            Method = 'Get'
+            ContentType = 'application/json; charset=utf-8'
+            TimeoutSec = $script:_ConnectionTimeout
         }
+
+        if ($script:_skipCertificateCheck) {
+            $invokeParams.SkipCertificateCheck = $true
+        }
+
+        If($Data.Count -gt 0) {
+            $invokeParams.Body = $Data
+        }
+        
+        $_rest = Invoke-RestMethod @invokeParams
+        
 
         If($_rest) {
             return $_rest
@@ -54,19 +67,37 @@ Function Invoke-bConnectGet() {
     }
 
     catch {
-        Try {
-            $_response = ConvertFrom-Json $_
-        }
+        $_errMsg = ""
 
+        Try {
+            if ($PSVersionTable.PSEdition -eq 'Core') {
+                # In PowerShell 7+, the actual response is in the stream of the exception's response object
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($stream)
+                $responseBody = $reader.ReadToEnd()
+                $reader.Close()
+                $stream.Close()
+                $_response = ConvertFrom-Json $responseBody
+            } else {
+                # In Windows PowerShell 5.1, the error record itself can sometimes be converted
+                $_response = ConvertFrom-Json $_
+            }
+        }
         Catch {
             $_response = $false
         }
 
         If($_response) {
-            Write-Error $_response.Message
+            $_errMsg = $_response.Message
         } else {
-            Write-Error $_
+            $_errMsg =  $_.Exception.Message
         }
+
+        If($Data) {
+            $_errMsg = "$($_errMsg) `nData: $($Data | Out-String)"
+        }
+
+        Write-Error $_errMsg
 
         return $false
     }

--- a/bConnect/Private/Invoke-bConnectPatch.ps1
+++ b/bConnect/Private/Invoke-bConnectPatch.ps1
@@ -46,7 +46,19 @@ Function Invoke-bConnectPatch() {
                 $_uri += "&ignoreAssignments=true"
             }
 
-            $_rest = Invoke-RestMethod -Uri $_uri -Body $_body -Credential $script:_connectCredentials -Method Patch -ContentType "application/json; charset=utf-8"
+            $invokeParams = @{
+                Uri = $_uri
+                Body = $_body
+                Credential = $script:_connectCredentials
+                Method = 'Patch'
+                ContentType = 'application/json; charset=utf-8'
+            }
+
+            if ($script:_skipCertificateCheck) {
+                $invokeParams.SkipCertificateCheck = $true
+            }
+
+            $_rest = Invoke-RestMethod @invokeParams
 
 
             If($_rest) {
@@ -63,9 +75,19 @@ Function Invoke-bConnectPatch() {
         $_errMsg = ""
 
         Try {
-            $_response = ConvertFrom-Json $_
+            if ($PSVersionTable.PSEdition -eq 'Core') {
+                # In PowerShell 7+, the actual response is in the stream of the exception's response object
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($stream)
+                $responseBody = $reader.ReadToEnd()
+                $reader.Close()
+                $stream.Close()
+                $_response = ConvertFrom-Json $responseBody
+            } else {
+                # In Windows PowerShell 5.1, the error record itself can sometimes be converted
+                $_response = ConvertFrom-Json $_
+            }
         }
-
         Catch {
             $_response = $false
         }
@@ -73,11 +95,11 @@ Function Invoke-bConnectPatch() {
         If($_response) {
             $_errMsg = $_response.Message
         } else {
-            $_errMsg =  $_
+            $_errMsg =  $_.Exception.Message
         }
 
         If($_body) {
-            $_errMsg = "$($_errMsg) `nHashtable: $($_body)"
+            $_errMsg = "$($_errMsg) `nBody: $($_body)"
         }
 
         Write-Error $_errMsg

--- a/bConnect/Private/Invoke-bConnectPost.ps1
+++ b/bConnect/Private/Invoke-bConnectPost.ps1
@@ -35,7 +35,19 @@ Function Invoke-bConnectPost() {
             # $_body = ConvertTo-Json $Data
 			$_body = ConvertTo-Json -InputObject $Data -Depth 5
 
-            $_rest = Invoke-RestMethod -Uri "$($script:_connectUri)/$($Version)/$($Controller)" -Body $_body -Credential $script:_connectCredentials -Method Post -ContentType "application/json; charset=utf-8"
+            $invokeParams = @{
+                Uri = "$($script:_connectUri)/$($Version)/$($Controller)"
+                Body = $_body
+                Credential = $script:_connectCredentials
+                Method = 'Post'
+                ContentType = 'application/json; charset=utf-8'
+            }
+
+            if ($script:_skipCertificateCheck) {
+                $invokeParams.SkipCertificateCheck = $true
+            }
+
+            $_rest = Invoke-RestMethod @invokeParams
             If($_rest) {
                 return $_rest
             } else {
@@ -50,9 +62,19 @@ Function Invoke-bConnectPost() {
         $_errMsg = ""
 
         Try {
-            $_response = ConvertFrom-Json $_
+            if ($PSVersionTable.PSEdition -eq 'Core') {
+                # In PowerShell 7+, the actual response is in the stream of the exception's response object
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($stream)
+                $responseBody = $reader.ReadToEnd()
+                $reader.Close()
+                $stream.Close()
+                $_response = ConvertFrom-Json $responseBody
+            } else {
+                # In Windows PowerShell 5.1, the error record itself can sometimes be converted
+                $_response = ConvertFrom-Json $_
+            }
         }
-
         Catch {
             $_response = $false
         }
@@ -60,11 +82,11 @@ Function Invoke-bConnectPost() {
         If($_response) {
             $_errMsg = $_response.Message
         } else {
-            $_errMsg =  $_
+            $_errMsg =  $_.Exception.Message
         }
 
         If($_body) {
-            $_errMsg = "$($_errMsg) `nHashtable: $($_body)"
+            $_errMsg = "$($_errMsg) `nBody: $($_body)"
         }
 
         Write-Error $_errMsg

--- a/bConnect/Private/Invoke-bConnectPut.ps1
+++ b/bConnect/Private/Invoke-bConnectPut.ps1
@@ -34,7 +34,19 @@ Function Invoke-bConnectPut() {
         If($Data.Count -gt 0) {
             $_body = ConvertTo-Json $Data
 
-            $_rest = Invoke-RestMethod -Uri "$($script:_connectUri)/$($Version)/$($Controller)" -Body $_body -Credential $script:_connectCredentials -Method Put -ContentType "application/json; charset=utf-8"
+            $invokeParams = @{
+                Uri = "$($script:_connectUri)/$($Version)/$($Controller)"
+                Body = $_body
+                Credential = $script:_connectCredentials
+                Method = 'Put'
+                ContentType = 'application/json; charset=utf-8'
+            }
+
+            if ($script:_skipCertificateCheck) {
+                $invokeParams.SkipCertificateCheck = $true
+            }
+
+            $_rest = Invoke-RestMethod @invokeParams
             If($_rest) {
                 return $_rest
             } else {
@@ -49,9 +61,19 @@ Function Invoke-bConnectPut() {
         $_errMsg = ""
 
         Try {
-            $_response = ConvertFrom-Json $_
+            if ($PSVersionTable.PSEdition -eq 'Core') {
+                # In PowerShell 7+, the actual response is in the stream of the exception's response object
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = New-Object System.IO.StreamReader($stream)
+                $responseBody = $reader.ReadToEnd()
+                $reader.Close()
+                $stream.Close()
+                $_response = ConvertFrom-Json $responseBody
+            } else {
+                # In Windows PowerShell 5.1, the error record itself can sometimes be converted
+                $_response = ConvertFrom-Json $_
+            }
         }
-
         Catch {
             $_response = $false
         }
@@ -59,11 +81,11 @@ Function Invoke-bConnectPut() {
         If($_response) {
             $_errMsg = $_response.Message
         } else {
-            $_errMsg =  $_
+            $_errMsg =  $_.Exception.Message
         }
 
         If($_body) {
-            $_errMsg = "$($_errMsg) `nHashtable: $($_body)"
+            $_errMsg = "$($_errMsg) `nBody: $($_body)"
         }
 
         Write-Error $_errMsg

--- a/bConnect/Public/Initialize-bConnect.ps1
+++ b/bConnect/Public/Initialize-bConnect.ps1
@@ -22,7 +22,11 @@ Function Initialize-bConnect() {
     )
 
     If($AcceptSelfSignedCertificate) {
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object ignoreCertificatePolicy
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            $script:_skipCertificateCheck = $AcceptSelfSignedCertificate
+        } else {
+            [System.Net.ServicePointManager]::CertificatePolicy = New-Object ignoreCertificatePolicy
+        }
     }
 
     $_uri = "https://$($Server):$($Port)/bConnect"

--- a/bConnect/bConnect.psm1
+++ b/bConnect/bConnect.psm1
@@ -16,7 +16,8 @@ $script:_bConnectFallbackVersion = "v1.0"
 $script:_ConnectionTimeout = 0
 
 # Only to ignore certificates errors (self-signed)
-Add-Type @"
+if ($PSVersionTable.PSEdition -ne 'Core') {
+    Add-Type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 
@@ -25,16 +26,17 @@ public class ignoreCertificatePolicy : ICertificatePolicy {
     public bool CheckValidationResult(ServicePoint sPoint, X509Certificate cert, WebRequest wRequest, int certProb) { return true; }
 }
 "@
+}
 
 # init the connection (uri and credentials)
 $script:_connectInitialized = $false
 
 # Load all scripts of the module
-foreach($modfile in (Get-ChildItem *.ps1 -Path "$PSScriptRoot\Private")){
+foreach ($modfile in (Get-ChildItem *.ps1 -Path "$PSScriptRoot\Private")) {
     . $modfile.FullName
 }
 
-foreach($modfile in (Get-ChildItem *.ps1 -Path "$PSScriptRoot\Public","$PSScriptRoot\Types")){
+foreach ($modfile in (Get-ChildItem *.ps1 -Path "$PSScriptRoot\Public", "$PSScriptRoot\Types")) {
     . $modfile.FullName
     Export-ModuleMember $modfile.BaseName
 }


### PR DESCRIPTION
This is more or less the bare minimum to get PowerShell 7 working.
It might be helpful for people in #53.

I tested it against a Baramundi Instance using Self Signed Certificates using PowerShell 7 and 5.
I only tested using the Get-bConnectInfo function as we only have a production setup.
If someone could test it against a Instance with trusted Certificates that would be helpful though I don't believe that it should make problems.
